### PR TITLE
Update README.md to include links to the leaf documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hi. I'm Maria Ma. I have an MPH in Infectious Diseases from UC Berkeley. My unde
 
 # What's in here
 
-* **what_we_know_en.md** is a living document that will contain information that will be as up to date as I can make it. The git commit history will have the information as needed. 
-* **20200301_practical_advice_en.md** is a document that was originally jointly crafted in a Google Doc by many others, containing the key things we wanted our communities to know. I can't take credit for any of this. Thank you to all the wonderful folks who helped out on this. This is undergoing translation into multiple languages, to be shared with friends and family that might be missed by more typical communications. 
+* **[what_we_know_en.md](what_we_know_en.md)** is a living document that will contain information that will be as up to date as I can make it. The git commit history will have the information as needed. 
+* **[20200301_practical_advice_en.md](20200301_practical_advice_en.md)** is a document that was originally jointly crafted in a Google Doc by many others, containing the key things we wanted our communities to know. I can't take credit for any of this. Thank you to all the wonderful folks who helped out on this. This is undergoing translation into multiple languages, to be shared with friends and family that might be missed by more typical communications. 
 
 Either submit an issue if you have more questions, or email me. If you dig around, my email is on my website.  


### PR DESCRIPTION
When I shared this content with some friends who were unfamiliar with github, they didn't know how to navigate from the root README.md to the referenced leaf documents. (Especially on mobile, this isn't super obvious.)  Filed #6 

This is just adding some links to help folks like that out.  This also makes a direct link to the README.md a good URL for sharing (as opposed to a link to the project root).