### PR TITLE
Reformat links to Twitter so you can tell there are two

### DIFF
--- a/what_we_know_en.md
+++ b/what_we_know_en.md
@@ -174,7 +174,7 @@ Also, [check out this explainer, which illustrates it way better than I can.](ht
 [Here is another post that is a great read on this subject!](https://medium.com/@ariadnelabs/social-distancing-this-is-not-a-snow-day-ac21d7fa78b4)
 
 ## I heard that hydroxychloroquinine is the cure! 
-Despite what certain political leaders and certain electric car makers say, we do not know if hydroxychloroquinine (HCQ) is a 'cure'. The paper for the clinical trial is shoddy at best and has a number of unanswered questions. Several [Twitter](https://twitter.com/jpogue1/status/1241138975802359813) [threads](https://twitter.com/GaetanBurgio/status/1241213107097100288) detail many of them, but the biggest problems are these: 
+Despite what certain political leaders and certain electric car makers say, we do not know if hydroxychloroquinine (HCQ) is a 'cure'. The paper for the clinical trial is shoddy at best and has a number of unanswered questions. Several Twitter threads [[1](https://twitter.com/jpogue1/status/1241138975802359813), [2](https://twitter.com/GaetanBurgio/status/1241213107097100288)] detail many of them, but the biggest problems are these: 
   * The outcome looked at was viral load, not clinical outcomes. 
   * Several patients who received HCQ were deemed ineligible for analysis because they weren't able to give a sample at the end timepoint, but probably would have been considered failures (as in, 3 got worse and had to go to the ICU (and so they couldn't give samples), 1 died, 1 couldn't take the side effects)
   * Viral load was not properly measured in most samples. 


### PR DESCRIPTION
The way GitHub formats links you can't tell whether a space is separating two links [like](https://images.app.goo.gl/pRqow7oVdqxhXsMKA) [this](https://images.app.goo.gl/J4XTFRybHkCobAqa7)  versus just one two-word link [like this](https://images.app.goo.gl/LfNW55PJX3nuqBSN9).